### PR TITLE
Add transactions support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,12 +246,38 @@ Use queryset, accessible by model's :code:`qs` property, to perform db operation
             author = book.author  # without select_related call, each author will hit db
             print(book.title, author.name)
 
+Transactions support
+********************
+It's possible to perform multiple model/queryset operations in transaction by using `transaction` module:
+
+.. code:: python
+
+    from minorm import transaction
+
+    with transaction.atomic():
+        # all db operations inside `atomic` block will run in one transaction
+        author = Person.objects.create(name="Steven King", age=19)
+        Book.objects.create(title="The Dark Tower: The Gunslinger", author=author)
+
+It's also possible to manually commit/rollback changes inside transaction block:
+
+.. code:: python
+
+    with transaction.atomic():
+        instance.save()  # instance is set for saving in transaction
+        if want_to_keep:
+            transaction.commit()  # permanently save instance in db
+        else:
+            transaction.rollback()  # remove instance from saving
+
+        # do more stuff if it's required
+
+
 TODO
 ----
 * add more model fields
 * test Postgresql support
 * add basic aggregation functions (SUM, COUNT, etc)
-* add transaction support
 
 Running tests
 -------------

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ What's the point?
 -----------------
 MinORM was designed as minimalistic ORM, to be as simple as possible.
 It's not production-ready solution, rather a proof of concept. The goal is to demonstrate example of an ORM,
-more-less applicable for usage, that could be created with python in a couple of days.
+more-less applicable for usage, that could be created with python in a short term of time.
 
 Usage
 -----

--- a/minorm/transaction.py
+++ b/minorm/transaction.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+
+from minorm.connectors import connector
+
+
+def commit(db=None):
+    if not db:
+        db = connector
+
+    db.connection.commit()
+
+
+def rollback(db=None):
+    if not db:
+        db = connector
+
+    db.connection.rollback()
+
+
+@contextmanager
+def atomic(db=None):
+    if not db:
+        db = connector
+
+    connector.set_autocommit(False)
+    with db.connection:
+        yield
+    connector.set_autocommit(True)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -14,6 +14,7 @@ class TestConnector:
         assert result is connector
         assert connector._connection
         assert connector._db_spec is db_spec
+        assert connector._autocommit
 
     def test_spec(self):
         db_spec = SQLiteSpec(":memory:")
@@ -25,6 +26,16 @@ class TestConnector:
         connector = Connector()
         with pytest.raises(ConnectorError, match=r'[cC]onnect.*'):
             connector.spec
+
+    @pytest.mark.parametrize('autocommit', [True, False])
+    def test_set_autocommit(self, test_db, autocommit):
+        test_db.set_autocommit(autocommit)
+        assert test_db._autocommit == autocommit
+
+    def test_set_autocommit_not_connected(self):
+        connector = Connector()
+        with pytest.raises(ConnectorError, match=r'[cC]onnect.*'):
+            connector.set_autocommit(True)
 
     def test_cursor_not_connected(self):
         connector = Connector()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,29 @@
+from minorm import transaction
+
+
+def test_rollback(test_model):
+
+    with transaction.atomic():
+        test_model.qs.create(name="foo", age=10)
+
+        transaction.rollback()
+        test_model.qs.create(name="bar", age=11)
+
+    results = test_model.qs.all()
+    assert len(results) == 1
+    assert results[0].name == "bar"
+
+
+def test_commit(test_model):
+    db = test_model._meta.db
+
+    with transaction.atomic():
+        test_model.qs.create(name="foo", age=10)
+        transaction.commit()
+
+        test_model.qs.create(name="bar", age=11)
+        db._connection.rollback()
+
+    results = test_model.qs.all()
+    assert len(results) == 1
+    assert results[0].name == "foo"


### PR DESCRIPTION
- add `set_autocommit` method of connector to turn on/off auto-commit mode of transactions
- add `connection` property of connector to access active connection and it's methods
- add `transaction` module with `atomic` context manager to implement transaction run and with `commit` / `rollback` functions